### PR TITLE
Fixes #2: Add keywords to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
   "authors": [
     "Indexia Technologies, ltd."
   ],
+  "keywords": [
+    "ember-addon"
+  ],
   "ember-addon": {
     "configPath": "tests/dummy/config"
   },


### PR DESCRIPTION
Ember-CLI detects addons by the presence of the "ember-addon" keyword. This pull-request adds the keyword.