### PR TITLE
Depending on arrays using a dependent key ending with `@each` is depr…

### DIFF
--- a/addon/tab.js
+++ b/addon/tab.js
@@ -71,7 +71,7 @@ export default Em.Component.extend(WithConfigMixin, {
     }
   }),
 
-  index: computed('tabList.tab_instances.@each', function() {
+  index: computed('tabList.tab_instances.[]', function() {
     return this.get('tabList.tab_instances').indexOf(this);
   }),
 


### PR DESCRIPTION
…ecated. Please refactor from `Ember.computed('tabList.tab_instances.@each', function() {});` to `Ember.computed('tabList.tab_instances.[]', function() {})`.