### PR TITLE
Fix deprecated dependent key ending in @each

### DIFF
--- a/addon/tab-panel.js
+++ b/addon/tab-panel.js
@@ -43,7 +43,7 @@ export default Em.Component.extend(WithConfigMixin, StyleBindingsMixin, {
    * @property tab
    * @type Tab
    */
-  tab: Em.computed('panels.length', 'tabList.tab_instances.@each', function() {
+  tab: Em.computed('panels.length', 'tabList.tab_instances.[]', function() {
     var index, tabs;
     index = this.get('panels').indexOf(this);
     tabs = this.get('tabList.tab_instances');


### PR DESCRIPTION
This causes this addon to cease working in Ember 2.0.
#18 fixed  the one in `addon/tab.js`, but there's still such an usage in `addon/tab-panel.js`.
