### PR TITLE
Fix Ember 2.0 deprecation

### DIFF
--- a/addon/tab-panel.js
+++ b/addon/tab-panel.js
@@ -43,7 +43,7 @@ export default Em.Component.extend(WithConfigMixin, StyleBindingsMixin, {
    * @property tab
    * @type Tab
    */
-  tab: Em.computed('panels.length', 'tabList.tab_instances.@each', function() {
+  tab: Em.computed('panels.length', 'tabList.tab_instances.[]', function() {
     var index, tabs;
     index = this.get('panels').indexOf(this);
     tabs = this.get('tabList.tab_instances');


### PR DESCRIPTION
Error message:

> Assertion Failed: Depending on arrays using a dependent key ending with `@each` is no longer supported. Please refactor from `Ember.computed('tabList.tab_instances.@each', function() {});` to `Ember.computed('tabList.tab_instances.[]', function() {})`.
